### PR TITLE
chore(ci): switch to next-gen CircleCI's convenience images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: &docker-image circleci/node:12
+      - image: &docker-image cimg/node:12.22
     steps:
       - checkout
       - restore_cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [unreleased]
+
+### CI
+1. [#14](https://github.com/influxdata/influxdb-gds-connector/pull/14): Switch to next-gen CircleCI's convenience images
+
 ## 2021.4 [2021-04-27]
 
 ### Features


### PR DESCRIPTION
## Proposed Changes

The current images are deprecated and no longer supported:

- https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034?mkt_tok=NDg1LVpNSC02MjYAAAF_aZ4aQBMMtwIJatxoGz4de_IMPoNZJOUAhbHY2j7KD_4fR38oMpf0qFjUBd15_QNaVKiHbjM5WE0emhPAvcNcagGm1rnILLJptARAtBWPhtQ
- https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
